### PR TITLE
feat: add o3-mini model support and fix cost calculations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ var DefaultConfig = Config{
 		EmbeddingsApiVersion:   "",
 		ChatApiKey:             "",
 		EmbeddingsApiKey:       "",
+		ReasoningEffort:        "",
 	},
 }
 
@@ -64,6 +65,7 @@ func LoadConfigs(rootCmd *cobra.Command, cwd string) *Config {
 	viper.SetDefault("ai_provider_config.embeddings_api_key", DefaultConfig.AIProviderConfig.EmbeddingsApiKey)
 	viper.SetDefault("ai_provider_config.chat_api_version", DefaultConfig.AIProviderConfig.ChatApiVersion)
 	viper.SetDefault("ai_provider_config.embeddings_api_version", DefaultConfig.AIProviderConfig.EmbeddingsApiVersion)
+	viper.SetDefault("ai_provider_config.reasoning_effort", DefaultConfig.AIProviderConfig.ReasoningEffort)
 
 	// Automatically read environment variables
 	viper.AutomaticEnv() // This will look for variables that match config keys directly
@@ -122,6 +124,7 @@ func bindEnv() {
 	_ = viper.BindEnv("ai_provider_config.embeddings_api_key", "EMBEDDINGS_API_KEY")
 	_ = viper.BindEnv("ai_provider_config.chat_api_version", "CHAT_API_VERSION")
 	_ = viper.BindEnv("ai_provider_config.embeddings_api_version", "EMBEDDINGS_API_VERSION")
+	_ = viper.BindEnv("ai_provider_config.reasoning_effort", "CHAT_REASONING_EFFORT")
 }
 
 // bindFlags binds the CLI flags to configuration values.
@@ -140,6 +143,7 @@ func bindFlags(rootCmd *cobra.Command) {
 	_ = viper.BindPFlag("ai_provider_config.embeddings_api_key", rootCmd.Flags().Lookup("embeddings_api_key"))
 	_ = viper.BindPFlag("ai_provider_config.chat_api_version", rootCmd.Flags().Lookup("chat_api_version"))
 	_ = viper.BindPFlag("ai_provider_config.embeddings_api_version", rootCmd.Flags().Lookup("embeddings_api_version"))
+	_ = viper.BindPFlag("ai_provider_config.reasoning_effort", rootCmd.Flags().Lookup("reasoning_effort"))
 }
 
 // InitFlags initializes the flags for the root command.
@@ -160,4 +164,5 @@ func InitFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().String("embeddings_api_key", DefaultConfig.AIProviderConfig.EmbeddingsApiKey, "The embeddings API key used to authenticate with the AI service provider.")
 	rootCmd.PersistentFlags().String("chat_api_version", DefaultConfig.AIProviderConfig.ChatApiVersion, "The API version used to authenticate with the chat AI service provider.")
 	rootCmd.PersistentFlags().String("embeddings_api_version", DefaultConfig.AIProviderConfig.EmbeddingsApiVersion, "The API version used to authenticate with the embeddings AI service provider.")
+	rootCmd.PersistentFlags().String("reasoning_effort", DefaultConfig.AIProviderConfig.ReasoningEffort, "Sets the AI model's reasoning effort level (e.g., 'low', 'medium', 'high'). This affects how thoroughly the model thinks through responses.")
 }

--- a/embed_data/models_details/model_details.tmpl
+++ b/embed_data/models_details/model_details.tmpl
@@ -11,6 +11,20 @@
       "supports_function_calling": true,
       "supports_prompt_caching": true
     },
+    "o3-mini": {
+      "max_tokens": 200000,
+      "max_input_tokens": 200000,
+      "max_output_tokens": 100000,
+      "input_cost_per_token": 0.0000011,
+      "output_cost_per_token": 0.0000044,
+      "cache_read_input_token_cost": 0.00000055,
+      "litellm_provider": "openai",
+      "mode": "chat",
+      "supports_function_calling": true,
+      "supports_parallel_function_calling": true,
+      "supports_vision": true,
+      "supports_prompt_caching": true
+    },
     "gpt-4o": {
       "max_tokens": 4096,
       "max_input_tokens": 128000,

--- a/providers/ai_provider.go
+++ b/providers/ai_provider.go
@@ -28,6 +28,7 @@ type AIProviderConfig struct {
 	EmbeddingsApiKey       string  `mapstructure:"embeddings_api_key"`
 	ChatApiVersion         string  `mapstructure:"chat_api_version"`
 	EmbeddingsApiVersion   string  `mapstructure:"embeddings_api_version"`
+	ReasoningEffort        string  `mapstructure:"reasoning_effort"`
 }
 
 // ChatProviderFactory creates a Provider based on the given provider config.
@@ -69,6 +70,7 @@ func ChatProviderFactory(config *AIProviderConfig, tokenManagement contracts2.IT
 			TokenManagement:      tokenManagement,
 			ChatApiVersion:       config.ChatApiVersion,
 			EmbeddingsApiVersion: config.EmbeddingsApiVersion,
+			ReasoningEffort:      config.ReasoningEffort,
 		}), nil
 	case "azure-openai":
 		return azure_openai.NewAzureOpenAIChatProvider(&azure_openai.AzureOpenAIConfig{

--- a/providers/openai/models/openai_chat_completion_request.go
+++ b/providers/openai/models/openai_chat_completion_request.go
@@ -7,6 +7,7 @@ type OpenAIChatCompletionRequest struct {
 	Temperature   *float32      `json:"temperature,omitempty"` // Optional field (pointer to float32)
 	Stream        bool          `json:"stream"`
 	StreamOptions StreamOptions `json:"stream_options"`
+	ReasoningEffort string      `json:"reasoning_effort,omitempty"` // Optional field
 }
 
 // Message Define the request body structure


### PR DESCRIPTION
Added support for o3-mini model including:

- Added o3-mini model to model_details.tmpl with correct token rates and specs:
  - Input: .10/1M tokens (/opt/homebrew/bin/bash.0000011 per token)
  - Output: .40/1M tokens (/opt/homebrew/bin/bash.0000044 per token)
  - Context length: 200k tokens
  - Support for function calling, vision, and parallel function calling

- Added temperature handling for o3/o1 models
  - Skip temperature parameter for o3/o1 models since they don't support it
  - Maintain temperature parameter for other models (e.g., gpt-4)

- Added support for reasoning_effort parameter
  - Added configuration in codai-config.yml
  - Added environment variable support (CHAT_REASONING_EFFORT)
  - Added command line flag support

- Code improvements:
  - Better cost calculation formatting
  - Cleaned up unused imports
  - Improved code organization